### PR TITLE
Conditionally enable log outputs for DCPSE

### DIFF
--- a/src/DCPSE/Dcpse.hpp
+++ b/src/DCPSE/Dcpse.hpp
@@ -699,12 +699,13 @@ protected:
 		this->rCut=rCut;
 		this->convergenceOrder=convergenceOrder;
 		auto & v_cl=create_vcluster();
+#ifdef DCPSE_VERBOSE
 		if(this->opt==LOAD){
 			if(v_cl.rank()==0)
 			{std::cout<<"Warning: Creating empty DC-PSE operator! Please use update or load to get kernels."<<std::endl;}
 			return;
 		}
-
+#endif
 		localEps.resize(particlesDomain.size_local());
 		localEpsInvPow.resize(particlesDomain.size_local());
 		kerOffsets.resize(particlesDomain.size_local());
@@ -780,7 +781,7 @@ protected:
 			++it;
 			++Counter;
 		}
-
+#ifdef DCPSE_VERBOSE
 		v_cl.sum(avgSpacingGlobal);
 		v_cl.sum(avgSpacingGlobal2);
 		v_cl.max(maxSpacingGlobal);
@@ -789,6 +790,7 @@ protected:
 		v_cl.execute();
 		if(v_cl.rank()==0)
 		{std::cout<<"DCPSE Operator Construction Complete. The global avg spacing in the support <h> is: "<<HOverEpsilon*avgSpacingGlobal/(T(Counter))<<" (c="<<HOverEpsilon<<"). Avg:"<<avgSpacingGlobal2/(T(Counter))<<" Range:["<<minSpacingGlobal<<","<<maxSpacingGlobal<<"]."<<std::endl;}
+#endif
 	}
 
 	T computeKernel(Point<dim, T> x, EMatrix<T, Eigen::Dynamic, 1> & a) const {


### PR DESCRIPTION
Everytime DC-PSE operators are created, there is a lot of output by default. 
This PR disables the output by default and makes it conditional with `#define DCPSE_VERBOSE`.
please squash and merge