### PR TITLE
fix gpu expression with odeint

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CUDA_ON_BACKEND STREQUAL "CUDA")
 	set(CUDA_SOURCES ${CUDA_SOURCES} DCPSE/DCPSE_op/tests/DCPSE_op_Solver_test.cu
 		DCPSE/DCPSE_op/tests/DCPSE_op_test_base_tests.cu
 		#DCPSE/DCPSE_op/tests/DCPSE_op_subset_test.cu
-		#OdeIntegrators/tests/Odeintegrators_test_gpu.cu
+		OdeIntegrators/tests/Odeintegrators_test_gpu.cu
 		DCPSE/DCPSE_op/tests/DCPSE_op_test_temporal.cu)
 endif()
 

--- a/src/OdeIntegrators/OdeIntegrators.hpp
+++ b/src/OdeIntegrators/OdeIntegrators.hpp
@@ -81,6 +81,61 @@ struct state_type_1d_ofp_gpu{
         return s1_ker;
     }
 };
+template<> struct has_vector_kernel< state_type_1d_ofp_gpu >
+    : std::true_type { };
+
+/*! \brief A 2d Odeint and Openfpm compatible structure.
+ *
+ *  Use the method this.data.get<d>() to refer to property of all the particles in the dimension d.
+ *
+ * d starts with 0.
+ *
+ */
+struct state_type_2d_ofp_ker{
+    state_type_2d_ofp_ker(){
+    }
+    typedef decltype(std::declval<texp_v_gpu<double>>().getVector().toKernel()) state_kernel;
+    typedef size_t size_type;
+    typedef int is_state_vector;
+    aggregate<state_kernel,state_kernel> data;
+
+    __host__ __device__ size_t size() const
+    { return data.get<0>().size(); }
+
+};
+/*! \brief A 1d Odeint and Openfpm compatible structure.
+ *
+ *  Use the method this.data.get<d>() to refer to property of all the particles in the dimension d.
+ *
+ * d starts with 0.
+ *
+ */
+struct state_type_2d_ofp_gpu{
+    state_type_2d_ofp_gpu(){
+    }
+    typedef size_t size_type;
+    typedef int is_state_vector;
+    aggregate<texp_v_gpu<double>,texp_v_gpu<double>> data;
+
+    size_t size() const
+    { return data.get<0>().size(); }
+
+    void resize(size_t n)
+    {
+        data.get<0>().resize(n);
+        data.get<1>().resize(n);
+    }
+    state_type_2d_ofp_ker toKernel() const
+    {
+        state_type_2d_ofp_ker s2_ker;
+        s2_ker.data.get<0>()=data.get<0>().getVector().toKernel();
+        s2_ker.data.get<1>()=data.get<1>().getVector().toKernel();
+        return s2_ker;
+    }
+};
+
+template<> struct has_vector_kernel< state_type_2d_ofp_gpu >
+    : std::true_type { };
 #endif
 
 namespace boost { namespace numeric { namespace odeint {

--- a/src/Operators/Vector/vector_dist_operators.hpp
+++ b/src/Operators/Vector/vector_dist_operators.hpp
@@ -1370,14 +1370,13 @@ public:
         }
 
         v.resize(v_exp.getVector().size_local());
+        constexpr bool cond=has_vector_kernel<vector>::type::value || std::is_same<vector,openfpm::vector<aggregate<T>,CudaMemory,memory_traits_inte>>::value;
 
-        if (has_vector_kernel<vector>::type::value == false)
+        if (has_vector_kernel<vector>::type::value == false && !std::is_same<vector,openfpm::vector<aggregate<T>,CudaMemory,memory_traits_inte>>::value)
         {
-            vector_dist_op_compute_op<0,
-                    vector_dist_expression_comp_sel<comp_host,
-                            has_vector_kernel<vector>::type::value>::type::value>
-            ::compute_expr(v,v_exp);
-        }
+			vector_dist_op_compute_op<0,
+									  vector_dist_expression_comp_sel<comp_host, cond>::type::value>::compute_expr(v, v_exp);
+		}
         else
         {
             vector_dist_op_compute_op<0,
@@ -1661,6 +1660,7 @@ public:
         typedef boost::mpl::bool_<false> NN_type;
 
 	typedef typename exp1::vtype vtype;
+	typedef typename boost::mpl::at<typename vtype::value_type::type,boost::mpl::int_<0>>::type T;
 
 	//! constructor from an expresssion
 
@@ -1855,18 +1855,21 @@ public:
             std::cout << __FILE__ << ":" << __LINE__ << " error on the right hand side of the expression you have to use non-subset properties" << std::endl;
             return this->getVector();
         }
+        v_exp.init();
+		auto &v = o1.getVector();
+        //v.resize(v_exp.getVector().size_local());
+        constexpr bool cond=has_vector_kernel<vtype>::type::value || std::is_same<vtype,openfpm::vector<aggregate<T>,CudaMemory,memory_traits_inte>>::value;
 
-		if (has_vector_kernel<vtype>::type::value == false)
+        if (has_vector_kernel<vtype>::type::value == false && !std::is_same<vtype,openfpm::vector<aggregate<T>,CudaMemory,memory_traits_inte>>::value)
 		{
-			vector_dist_op_compute_op<exp1::prop,vector_dist_expression_comp_sel<comp_host,
-																	   	  has_vector_kernel<vtype>::type::value>::type::value>
-			::compute_expr_slice(o1.getVector(),v_exp,comp);
+			vector_dist_op_compute_op<exp1::prop,vector_dist_expression_comp_sel<comp_host,cond>::type::value>
+			::compute_expr_slice(v,v_exp,comp);
 		}
 		else
 		{
 			vector_dist_op_compute_op<exp1::prop,vector_dist_expression_comp_sel<comp_dev,
 		   	  	  	  	  	  	  	  	  	  	  	  	  	  	  	  	  has_vector_kernel<vtype>::type::value>::type::value>
-			::compute_expr_slice(o1.getVector(),v_exp,comp);
+			::compute_expr_slice(v,v_exp,comp);
 		}
 
 		return this->getVector();


### PR DESCRIPTION
The composite expressions for Gpu with odeint custom state type was broken becuase the comp selector was not correctly updated for that case. 

See the non-composite case: https://github.com/mosaic-group/openfpm_numerics/blob/2c27144a014f7a53947d2aaeb0fcb56ad2329263/src/Operators/Vector/vector_dist_operators.hpp#L1340